### PR TITLE
Update ex6.asm

### DIFF
--- a/ex6/ex6.asm
+++ b/ex6/ex6.asm
@@ -1,15 +1,16 @@
 global _start
 
 _start:
-    sub esp, 4
+    sub esp, 5
     mov [esp], byte 'H'
     mov [esp+1], byte 'e'
     mov [esp+2], byte 'y'
     mov [esp+3], byte '!'
+    mov [esp+4], byte 0x0a
     mov eax, 4    ; sys_write system call
     mov ebx, 1    ; stdout file descriptor
     mov ecx, esp  ; bytes to write
-    mov edx, 4    ; number of bytes to write
+    mov edx, 5    ; number of bytes to write
     int 0x80      ; perform system call
     mov eax, 1    ; sys_exit system call
     mov ebx, 0    ; exit status is 0


### PR DESCRIPTION
Hello there! Thanks for the lessons.

### Source
I was watching [Intro to x86 Assembly Language (Part 3)](https://youtu.be/_UP7WJ8iODY?list=PLmxT2pVYo5LB5EzTPZGfFN0c2GDiSXgQe&t=605) while trying out everything on my terminal open on the right. Found something weird running the code at `10:05`.

### Bug
It printed a highlighted `%` at the end of the message on my system.
```
 raisinten@raisinten-HP-Pavilion-dv6-Notebook-PC  ~/Desktop/assembly  cat prog.asm 
global _start

_start:
    sub esp, 4
    mov [esp], byte 'H'
    mov [esp+1], byte 'e'
    mov [esp+2], byte 'y'
    mov [esp+3], byte '!'
    mov eax, 4    ; sys_write system call
    mov ebx, 1    ; stdout file descriptor
    mov ecx, esp  ; bytes to write
    mov edx, 4    ; number of bytes to write
    int 0x80      ; perform system call
    mov eax, 1    ; sys_exit system call
    mov ebx, 0    ; exit status is 0
    int 0x80

 raisinten@raisinten-HP-Pavilion-dv6-Notebook-PC  ~/Desktop/assembly  make
rm *.o* -rf
nasm -f elf32 prog.asm -o prog.o
ld -m elf_i386 prog.o -o prog.out
 raisinten@raisinten-HP-Pavilion-dv6-Notebook-PC  ~/Desktop/assembly  ./prog.out 
Hey!% 
```
### What I did
So, I increased the stack size and added an `0x0a` at the end of the string and added `1` to the contents of the `edx` register. It seemed that the problem was solved. I tried to see the exit status of the code at the end of part 1 by moving `len` to the `ebx` register before exiting. Guess what? It added a `1` to the string length as well!

### Conclusion
It seems like we need to include the contribution of the `0x0a` byte when we address the length of the string. Please feel free to correct me if I went wrong anywhere. Thank you. Stay safe. :)